### PR TITLE
Fix checksum computation

### DIFF
--- a/teleinfo.py
+++ b/teleinfo.py
@@ -55,7 +55,7 @@ def _readframe(ser):
             logging.debug(f'Received frame {line}')
 
             # cleanup + ascii conversion
-            line_str = line.replace(STOP_FRAME,b'').replace(START_FRAME,b'').decode('ascii').rstrip()
+            line_str = ''.join(line.replace(STOP_FRAME,b'').replace(START_FRAME,b'').decode('ascii').splitlines())
 
             parts = line_str.split(separator)
             key = parts[0]


### PR DESCRIPTION
Depending value, checksum might be a blank space `' '`
Because of current implementation, rstrip() removed this space, and checksum not picked correctly on the line.

Example (see ERQ4) :

```
2023-10-06 16:42:53,925 - DEBUG: Received frame b'ERQ3\t000250810\tM\r\n'
2023-10-06 16:42:53,929 - DEBUG: Raw data line received: ERQ3	000250810	, key: ERQ3, date: None, value: 000250810, checksum: M, parts: 3.
2023-10-06 16:42:53,951 - DEBUG: Received frame b'ERQ4\t006078238\t \r\n'
2023-10-06 16:42:53,956 - DEBUG: Raw data line received: ERQ4	006078238, key: ERQ4, date: None, value: 006078238, checksum: 006078238, parts: 2.
2023-10-06 16:42:53,964 - ERROR: Invalid checksum for key ERQ4 : ERQ4	6078238
```

This PR replaces rstrip usage with splitlines(), and resolves the checksum issue :

```
2023-10-06 16:53:11,862 - DEBUG: Received frame b'ERQ3\t000250869\t[\r\n'
2023-10-06 16:53:11,866 - DEBUG: Raw data line received: ERQ3	000250869	[, key: ERQ3, date: None, value: 000250869, checksum: [, parts: 3.
2023-10-06 16:53:11,886 - DEBUG: Received frame b'ERQ4\t006078238\t \r\n'
2023-10-06 16:53:11,891 - DEBUG: Raw data line received: ERQ4	006078238	 , key: ERQ4, date: None, value: 006078238, checksum:  , parts: 3.
```
